### PR TITLE
Removed hyphens from page mastheads and capitalized first word.

### DIFF
--- a/AudioWebApp6/Client/Pages/Components/MastHead.razor
+++ b/AudioWebApp6/Client/Pages/Components/MastHead.razor
@@ -9,13 +9,13 @@
 
 
 
-    @code {
+@code {
     public string? CurrentPageTitle ;
     protected override void OnInitialized()
     {
         NavigationManager.LocationChanged += HandleLocationChanged;
         UpdatePageTitle(NavigationManager.Uri);
-        
+
 
     }
     private void HandleLocationChanged(object sender, LocationChangedEventArgs e)
@@ -32,14 +32,41 @@
     {
         var segments = uri.Split('/');
         string? substring = segments.LastOrDefault();
-        if(substring == null || substring == "")
+        if (substring == null || substring == "")
         {
             return string.Empty;
         }
         else
         {
-            return substring.Substring(0, 1).ToUpper() + substring.Substring(1);
+            return RemoveHyphensAndCapitalize(substring.Substring(0));
         }
+    }
+    private string RemoveHyphensAndCapitalize(string title)
+    {
+        // Check if the input string contains '-'
+        if (title.Contains('-'))
+        {
+            string[] words = title.Split('-');
 
+            // Capitalize the first letter of each word
+            for (int i = 0; i < words.Length; i++)
+            {
+                if (!string.IsNullOrEmpty(words[i]))
+                {
+                    words[i] = char.ToUpper(words[i][0]) + words[i].Substring(1);
+                }
+            }
+
+            // Join the words back together
+            string capitalizedString = string.Join(" ", words);
+
+            return capitalizedString;
+        }
+        else
+        {
+            // If no '-' found, just capitalize the first letter of the whole string
+            title = char.ToUpper(title[0]) + title.Substring(1);
+            return title;
+        }
     }
 }

--- a/AudioWebApp6/Client/Pages/VerseByVerse.razor
+++ b/AudioWebApp6/Client/Pages/VerseByVerse.razor
@@ -1,4 +1,4 @@
-﻿@page "/verse"
+﻿@page "/verse-by-verse"
 @using AudioWebApp.Client.Services
 @inject SharedDataService sharedDataService
 @inject ApiService apiService

--- a/AudioWebApp6/Client/Shared/NavMenu.razor
+++ b/AudioWebApp6/Client/Shared/NavMenu.razor
@@ -5,7 +5,7 @@
         <MudNavLink Href="announcements" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Event">Announcements</MudNavLink>
         <MudNavLink Href="radio" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Radio" >Radio</MudNavLink>
         <MudNavLink Href="topical" Match="NavLinkMatch.Prefix" Icon="@topicalIcon">Topical</MudNavLink>
-        <MudNavLink Href="verse" Match="NavLinkMatch.Prefix" Icon="@vbvIcon" >Verse by Verse</MudNavLink>
+        <MudNavLink Href="verse-by-verse" Match="NavLinkMatch.Prefix" Icon="@vbvIcon" >Verse by Verse</MudNavLink>
         <MudNavLink Href="book-overviews" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.LibraryBooks">Book Overview</MudNavLink>
         <MudNavLink Href="debates" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.SpeakerGroup">Debates</MudNavLink>
         <MudNavLink Href="teachings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.School">Teachings</MudNavLink>


### PR DESCRIPTION
Masthead titles now match with navigation tabs titles.