### PR TITLE
Updated font size in sticky player title to address long titles.

### DIFF
--- a/AudioWebApp6/Client/Shared/MainLayout.razor
+++ b/AudioWebApp6/Client/Shared/MainLayout.razor
@@ -42,11 +42,11 @@
                         </div>
                         <div class="d-flex flex-grow-1 gap-0">
                             <MudPaper Class="flex-auto d-flex py-0 justify-center align-center"  Width="100%" Elevation="0">
-                                <MudText>@audioTitle</MudText>
+                                <MudText class="audioTitleText">@audioTitle</MudText>
                             </MudPaper>
                         </div>  
                         <div class="d-flex flex-grow-1 gap-0">
-                            <MudPaper Class="flex-auto d-flex py-3 justify-center align-center"  Width="100%" Elevation="0">
+                            <MudPaper Class="flex-auto d-flex py-1 justify-center align-center"  Width="100%" Elevation="0">
                                 <audio id="audioPlayer"src="@audioSource" controls autoplay title="@audioTitle" artist="@artist" category="@category"></audio>
                             </MudPaper>
                         </div>

--- a/AudioWebApp6/Client/Shared/MainLayout.razor.css
+++ b/AudioWebApp6/Client/Shared/MainLayout.razor.css
@@ -35,3 +35,7 @@
     align-content: center;
     justify-content: center;
 }
+::deep p.mud-typography.mud-typography-body1.audioTitleText{
+    font-size:14px;
+    padding-left:6px;
+}


### PR DESCRIPTION
Font size reduced to 14 pixels from 16 pixels. Padding reduced around audio-element by 4 pixels.