### PR TITLE
Removed vh attributes from MudBlazor elements. Adjusted inline styles…

### DIFF
--- a/AudioWebApp6/Client/Pages/Radio.razor
+++ b/AudioWebApp6/Client/Pages/Radio.razor
@@ -5,22 +5,22 @@
 
 <div>
 <MudCardContent class="radio-container">
-    <MudPaper Class="d-flex justify-center align-center pt-4 px-1" Elevation="0" Height="6vh">
+    <MudPaper Class="d-flex justify-center align-center pt-4 px-1" Elevation="0" >
         <p class="lead">The Narrow Path is BroadCast Live</p> 
     </MudPaper>
-    <MudPaper Class="d-flex justify-center align-center py-0 px-1 pb-4" Elevation="0" Height="6vh">
+    <MudPaper Class="d-flex justify-center align-center py-0 px-1 pb-4" Elevation="0" >
         <p> Weekdays from 2:00 P.M. - 3:00 P.M. PT</p>
     </MudPaper>
-    <MudPaper Class="d-flex justifiy-center align-center pb-2" style="padding-right:8px;" Elevation="0">
+    <MudPaper Class="d-flex justifiy-center align-center " style="padding-right:8px;" Elevation="0">
             <MudImage Src="./images/steve_gregg.png" />
     </MudPaper>
-    <MudPaper Class="d-flex justify-center align-center py-0 pt-2" Elevation="0" Height="10vh">
-        <MudButton Variant="Variant.Filled" Class="rounded-circle pa-7" style="color:green;" OnClick="@((e) => OpenDialog())">
+    <MudPaper Class="d-flex justify-center align-center " Elevation="0" >
+        <MudButton Variant="Variant.Filled" Class="rounded-circle pa-6" style="color:green;" OnClick="@((e) => OpenDialog())">
             <MudIcon Icon="@Icons.Material.Filled.Phone" Size="Size.Medium" ></MudIcon>
         </MudButton>
     </MudPaper>
-    <MudPaper Class="d-flex justify-center align-center py-1 pt-2" Elevation="0" Height="15vh">
-        <MudButtonGroup Size="Size.Large" Variant="Variant.Filled">
+    <MudPaper Class="d-flex justify-center align-center" style="padding-top:30px;" Elevation="0" >
+        <MudButtonGroup Size="Size.Large"  Variant="Variant.Filled">
                 <MudButton Style="color:#d8e6fe;" Href="https://podcasts.apple.com/us/podcast/the-narrow-path-radio-program-1-hour/id171641936" Target="_blank">Podcast</MudButton>
                 <MudButton Style="color:#d8e6fe;" Href="https://22963.live.streamtheworld.com/KPDQAM_SC" Target="_blank">Live</MudButton>
                 <MudButton Style="color:#d8E6Fe;" Href="https://www.matthew713.com/search" Target="_blank" StartIcon="@Icons.Material.Filled.Search" >Search</MudButton>


### PR DESCRIPTION
VH attribute misbehaving when radio in landscape mode. Removed vh attributes and added inline style attribute to work with MB Class attribute to maintain consistency for MudPaper elements.