### PR TITLE
Updated Index page feature card CSS.

### DIFF
--- a/AudioWebApp6/Client/Pages/Index.razor.css
+++ b/AudioWebApp6/Client/Pages/Index.razor.css
@@ -59,6 +59,7 @@
     font-size: 16px;
 }
 ::deep div.mud-paper.mud-elevation-1.mud-card.feature-card {
+    align-content: start;
     width: 250px;
     height:400px;
     background-color: #D8E6FE;


### PR DESCRIPTION
The feature cards without buttons were showing space above images on desktop browsers. Changed to feature card CSS to align-content: start; Which removed the space being added to those two cards without buttons.