### PR TITLE
Inject silent audio element into iOS PWA's to prevent destruction of the DOM when suspended offscreen

### DIFF
--- a/AudioWebApp6/Client/wwwroot/scripts/audioObserver.js
+++ b/AudioWebApp6/Client/wwwroot/scripts/audioObserver.js
@@ -84,18 +84,15 @@ function installIOSPatchIfRequired() {
     const isPWA = window.matchMedia("(display-mode: standalone)").matches;
 
     if (isIOS && isPWA) {
-        const audioElement = document.getElementById("audioPlayer");
-        let silenceElement = document.getElementById("silencePlayer");
-        if (!silenceElement) {
-            silenceElement = document.createElement('audio');
+        if (!document.getElementById("silencePlayer")) {
+            const silenceElement = document.createElement('audio');
             silenceElement.id = "silencePlayer";
             silenceElement.autoplay = true;
             silenceElement.playbackRate = 0.0;
-
             // 16 samples of silence, encoded as an unsigned 8 bit PCM WAV via Audacity, then converted to base64.
-            const silentDataURI = 'data:audio/wav;base64,UklGRjQAAABXQVZFZm10IBAAAAABAAEARKwAAESsAAABAAgAZGF0YRAAAACAgICAgICAgICAgICAgICA';
-            silenceElement.setAttribute('src', silentDataURI);
-
+            silenceElement.src = 'data:audio/wav;base64,UklGRjQAAABXQVZFZm10IBAAAAABAAEARKwAAESsAAABAAgAZGF0YRAAAACAgICAgICAgICAgICAgICA';
+            
+            const audioElement = document.getElementById("audioPlayer");
             audioElement.parentElement.appendChild(silenceElement);
         }
     }

--- a/AudioWebApp6/Client/wwwroot/scripts/audioObserver.js
+++ b/AudioWebApp6/Client/wwwroot/scripts/audioObserver.js
@@ -7,6 +7,8 @@ function getStartTime(key) {
     });
 }
 function timeStamper(storedValue) {
+    installIOSPatchIfRequired()
+
     const audioElement = document.getElementById("audioPlayer");
     audioElement.preload = 'auto';
     audioElement.addEventListener('loadedmetadata', () => audioElement.currentTime = storedValue);
@@ -66,5 +68,35 @@ function timeStamper(storedValue) {
         navigator.mediaSession.setActionHandler('seekbackward', () => {
             audioReverse();
         })
+    }
+}
+
+// iOS PWA's demonstrate a bug whereby the DOM elements are seemingly
+// deallocated when media playback stops, and can no longer be restarted.
+// To circumvent this, we create a player that is loaded to a silent mp3 and
+// has playback rate of 0. This causes it to be "playing" indefinitely, without
+// interfering with OS hooks to automatically determine media position.
+function installIOSPatchIfRequired() { 
+    // https://stackoverflow.com/questions/9038625/detect-if-device-is-ios
+    const isIOS = ['iPad', 'iPhone', 'iPod'].includes(navigator.platform)
+        // iPad on iOS 13 detection
+        || (navigator.userAgent.includes("Mac") && "ontouchend" in document);
+    const isPWA = window.matchMedia("(display-mode: standalone)").matches;
+
+    if (isIOS && isPWA) {
+        const audioElement = document.getElementById("audioPlayer");
+        let silenceElement = document.getElementById("silencePlayer");
+        if (!silenceElement) {
+            silenceElement = document.createElement('audio');
+            silenceElement.id = "silencePlayer";
+            silenceElement.autoplay = true;
+            silenceElement.playbackRate = 0.0;
+
+            // 16 samples of silence, encoded as an unsigned 8 bit PCM WAV via Audacity, then converted to base64.
+            const silentDataURI = 'data:audio/wav;base64,UklGRjQAAABXQVZFZm10IBAAAAABAAEARKwAAESsAAABAAgAZGF0YRAAAACAgICAgICAgICAgICAgICA';
+            silenceElement.setAttribute('src', silentDataURI);
+
+            audioElement.parentElement.appendChild(silenceElement);
+        }
     }
 }


### PR DESCRIPTION
Fixes #124.

It's not the prettiest, but I've done what I can to make it as selectively applied as possible. In my testing it does correctly cause the playback to be resumable via the native UI's when paused and the application is in the background and/or the phone is locked, which was not previously possible.